### PR TITLE
Port yuzu commit: "yuzu/CMakeLists: Disable implicit QString co… (#5074)

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -244,6 +244,10 @@ target_compile_definitions(citra-qt PRIVATE
 
     # Disable implicit QString->QUrl conversions to enforce use of proper resolving functions.
     -DQT_NO_URL_CAST_FROM_STRING
+
+    # Disable implicit conversions from/to C strings
+    -DQT_NO_CAST_FROM_ASCII
+    -DQT_NO_CAST_TO_ASCII
 )
 
 if (CITRA_ENABLE_COMPATIBILITY_REPORTING)

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -190,7 +190,9 @@ GRenderWindow::GRenderWindow(QWidget* parent_, EmuThread* emu_thread)
     : QWidget(parent_), emu_thread(emu_thread) {
 
     setWindowTitle(QStringLiteral("Citra %1 | %2-%3")
-                       .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));
+                       .arg(QString::fromUtf8(Common::g_build_name),
+                            QString::fromUtf8(Common::g_scm_branch),
+                            QString::fromUtf8(Common::g_scm_desc)));
     setAttribute(Qt::WA_AcceptTouchEvents);
     auto layout = new QHBoxLayout(this);
     layout->setMargin(0);

--- a/src/citra_qt/camera/still_image_camera.cpp
+++ b/src/citra_qt/camera/still_image_camera.cpp
@@ -36,14 +36,16 @@ const std::string StillImageCameraFactory::GetFilePath() const {
         return last_path;
     }
     QList<QByteArray> types = QImageReader::supportedImageFormats();
-    QList<QString> temp_filters;
+    QStringList temp_filters;
     for (QByteArray type : types) {
-        temp_filters << QString("*." + QString(type));
+        temp_filters << QStringLiteral("*.%1").arg(QString::fromUtf8(type));
     }
 
-    QString filter = QObject::tr("Supported image files (%1)").arg(temp_filters.join(" "));
+    QString filter =
+        QObject::tr("Supported image files (%1)").arg(temp_filters.join(QLatin1Char{' '}));
     last_path =
-        QFileDialog::getOpenFileName(nullptr, QObject::tr("Open File"), ".", filter).toStdString();
+        QFileDialog::getOpenFileName(nullptr, QObject::tr("Open File"), QStringLiteral("."), filter)
+            .toStdString();
     return last_path;
 }
 

--- a/src/citra_qt/cheats.cpp
+++ b/src/citra_qt/cheats.cpp
@@ -54,7 +54,7 @@ void CheatDialog::LoadCheats() {
     for (size_t i = 0; i < cheats.size(); i++) {
         QCheckBox* enabled = new QCheckBox();
         enabled->setChecked(cheats[i]->IsEnabled());
-        enabled->setStyleSheet("margin-left:7px;");
+        enabled->setStyleSheet(QStringLiteral("margin-left:7px;"));
         ui->tableCheats->setItem(i, 0, new QTableWidgetItem());
         ui->tableCheats->setCellWidget(i, 0, enabled);
         ui->tableCheats->setItem(
@@ -90,7 +90,7 @@ bool CheatDialog::SaveCheat(int row) {
     }
 
     // Check if the cheat lines are valid
-    auto code_lines = ui->textCode->toPlainText().split("\n", QString::SkipEmptyParts);
+    auto code_lines = ui->textCode->toPlainText().split(QLatin1Char{'\n'}, QString::SkipEmptyParts);
     for (int i = 0; i < code_lines.size(); ++i) {
         Cheats::GatewayCheat::CheatLine cheat_line(code_lines[i].toStdString());
         if (cheat_line.valid)
@@ -195,9 +195,9 @@ void CheatDialog::OnDeleteCheat() {
 
     LoadCheats();
     if (cheats.empty()) {
-        ui->lineName->setText("");
-        ui->textCode->setPlainText("");
-        ui->textNotes->setPlainText("");
+        ui->lineName->clear();
+        ui->textCode->clear();
+        ui->textNotes->clear();
         ui->lineName->setEnabled(false);
         ui->textCode->setEnabled(false);
         ui->textNotes->setEnabled(false);
@@ -231,11 +231,11 @@ void CheatDialog::OnAddCheat() {
 
     // create a dummy item
     ui->tableCheats->setItem(row, 1, new QTableWidgetItem(tr("[new cheat]")));
-    ui->tableCheats->setItem(row, 2, new QTableWidgetItem(""));
-    ui->lineName->setText("");
+    ui->tableCheats->setItem(row, 2, new QTableWidgetItem(QString{}));
+    ui->lineName->clear();
     ui->lineName->setPlaceholderText(tr("[new cheat]"));
-    ui->textCode->setPlainText("");
-    ui->textNotes->setPlainText("");
+    ui->textCode->clear();
+    ui->textNotes->clear();
     ui->lineName->setEnabled(true);
     ui->textCode->setEnabled(true);
     ui->textNotes->setEnabled(true);

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -116,7 +116,8 @@ void Config::ReadAudioValues() {
     Settings::values.mic_input_type = static_cast<Settings::MicInputType>(
         ReadSetting(QStringLiteral("mic_input_type"), 0).toInt());
     Settings::values.mic_input_device =
-        ReadSetting(QStringLiteral("mic_input_device"), Frontend::Mic::default_device_name)
+        ReadSetting(QStringLiteral("mic_input_device"),
+                    QString::fromUtf8(Frontend::Mic::default_device_name))
             .toString()
             .toStdString();
 
@@ -635,7 +636,7 @@ void Config::SaveAudioValues() {
     WriteSetting(QStringLiteral("volume"), Settings::values.volume, 1.0f);
     WriteSetting(QStringLiteral("mic_input_device"),
                  QString::fromStdString(Settings::values.mic_input_device),
-                 Frontend::Mic::default_device_name);
+                 QString::fromUtf8(Frontend::Mic::default_device_name));
     WriteSetting(QStringLiteral("mic_input_type"),
                  static_cast<int>(Settings::values.mic_input_type), 0);
 
@@ -1006,7 +1007,7 @@ QVariant Config::ReadSetting(const QString& name) const {
 
 QVariant Config::ReadSetting(const QString& name, const QVariant& default_value) const {
     QVariant result;
-    if (qt_config->value(name + "/default", false).toBool()) {
+    if (qt_config->value(name + QStringLiteral("/default"), false).toBool()) {
         result = default_value;
     } else {
         result = qt_config->value(name, default_value);
@@ -1020,7 +1021,7 @@ void Config::WriteSetting(const QString& name, const QVariant& value) {
 
 void Config::WriteSetting(const QString& name, const QVariant& value,
                           const QVariant& default_value) {
-    qt_config->setValue(name + "/default", value == default_value);
+    qt_config->setValue(name + QStringLiteral("/default"), value == default_value);
     qt_config->setValue(name, value);
 }
 

--- a/src/citra_qt/configuration/configure_camera.cpp
+++ b/src/citra_qt/configuration/configure_camera.cpp
@@ -183,8 +183,9 @@ void ConfigureCamera::StartPreviewing() {
     ui->preview_button->setHidden(true);
     preview_width = ui->preview_box->size().width();
     preview_height = preview_width * 0.75;
-    ui->preview_box->setToolTip(tr("Resolution: ") + QString::number(preview_width) + "*" +
-                                QString::number(preview_height));
+    ui->preview_box->setToolTip(
+        tr("Resolution: %1*%2")
+            .arg(QString::number(preview_width), QString::number(preview_height)));
     // Load previewing camera
     previewing_camera = Camera::CreateCameraPreview(
         camera_name[camera_selection], camera_config[camera_selection], preview_width,
@@ -270,7 +271,7 @@ void ConfigureCamera::OnToolButtonClicked() {
     QList<QByteArray> types = QImageReader::supportedImageFormats();
     QList<QString> temp_filters;
     for (const QByteArray& type : types) {
-        temp_filters << QString("*." + QString::fromUtf8(type));
+        temp_filters << QStringLiteral("*.%1").arg(QString::fromUtf8(type));
     }
     QString filter = tr("Supported image files (%1)").arg(temp_filters.join(QStringLiteral(" ")));
     QString path = QFileDialog::getOpenFileName(this, tr("Open File"), QStringLiteral("."), filter);

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -72,11 +72,11 @@ void ConfigureEnhancements::updateShaders(Settings::StereoRenderOption stereo_op
     ui->shader_combobox->clear();
 
     if (stereo_option == Settings::StereoRenderOption::Anaglyph)
-        ui->shader_combobox->addItem("dubois (builtin)");
+        ui->shader_combobox->addItem(QStringLiteral("dubois (builtin)"));
     else if (stereo_option == Settings::StereoRenderOption::Interlaced)
-        ui->shader_combobox->addItem("horizontal (builtin)");
+        ui->shader_combobox->addItem(QStringLiteral("horizontal (builtin)"));
     else
-        ui->shader_combobox->addItem("none (builtin)");
+        ui->shader_combobox->addItem(QStringLiteral("none (builtin)"));
 
     ui->shader_combobox->setCurrentIndex(0);
 

--- a/src/citra_qt/debugger/wait_tree.cpp
+++ b/src/citra_qt/debugger/wait_tree.cpp
@@ -178,7 +178,7 @@ QString WaitTreeThread::GetText() const {
     QString pc_info = tr(" PC = 0x%1 LR = 0x%2")
                           .arg(thread.context->GetProgramCounter(), 8, 16, QLatin1Char('0'))
                           .arg(thread.context->GetLinkRegister(), 8, 16, QLatin1Char('0'));
-    return WaitTreeWaitObject::GetText() + pc_info + " (" + status + ") ";
+    return QStringLiteral("%1%2 (%3) ").arg(WaitTreeWaitObject::GetText(), pc_info, status);
 }
 
 QColor WaitTreeThread::GetColor() const {

--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -120,14 +120,15 @@ void GameListWorker::run() {
         if (game_dir.path == QStringLiteral("INSTALLED")) {
             QString games_path =
                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)) +
-                "Nintendo "
-                "3DS/00000000000000000000000000000000/"
-                "00000000000000000000000000000000/title/00040000";
+                QStringLiteral("Nintendo "
+                               "3DS/00000000000000000000000000000000/"
+                               "00000000000000000000000000000000/title/00040000");
             QString demos_path =
                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)) +
-                "Nintendo "
-                "3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/"
-                "00040002";
+                QStringLiteral(
+                    "Nintendo "
+                    "3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/"
+                    "00040002");
             watch_list.append(games_path);
             watch_list.append(demos_path);
             auto* const game_list_dir = new GameListDir(game_dir, GameListItemType::InstalledDir);
@@ -137,7 +138,7 @@ void GameListWorker::run() {
         } else if (game_dir.path == QStringLiteral("SYSTEM")) {
             QString path =
                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)) +
-                "00000000000000000000000000000000/title/00040010";
+                QStringLiteral("00000000000000000000000000000000/title/00040010");
             watch_list.append(path);
             auto* const game_list_dir = new GameListDir(game_dir, GameListItemType::SystemDir);
             emit DirEntryReady(game_list_dir);

--- a/src/citra_qt/loading_screen.cpp
+++ b/src/citra_qt/loading_screen.cpp
@@ -134,7 +134,7 @@ void LoadingScreen::Prepare(Loader::AppLoader& loader) {
     }
     std::string title;
     if (loader.ReadTitle(title) == Loader::ResultStatus::Success) {
-        ui->title->setText(QString("Now Loading\n") + QString::fromStdString(title));
+        ui->title->setText(tr("Now Loading\n%1").arg(QString::fromStdString(title)));
     }
     eta_shown = false;
     OnLoadProgress(VideoCore::LoadCallbackStage::Prepare, 0, 0);
@@ -150,7 +150,7 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
     const auto now = high_resolution_clock::now();
     // reset the timer if the stage changes
     if (stage != previous_stage) {
-        ui->progress_bar->setStyleSheet(progressbar_style.at(stage));
+        ui->progress_bar->setStyleSheet(QString::fromUtf8(progressbar_style.at(stage)));
         // Hide the progress bar during the prepare stage
         if (stage == VideoCore::LoadCallbackStage::Prepare) {
             ui->progress_bar->hide();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -637,7 +637,10 @@ void GMainWindow::ConnectMenuEvents() {
             ->key());
     ui.action_Screen_Layout_Swap_Screens->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     ui.action_Screen_Layout_Upright_Screens->setShortcut(
-        hotkey_registry.GetHotkey("Main Window", "Rotate Screens Upright", this)->key());
+        hotkey_registry
+            .GetHotkey(QStringLiteral("Main Window"), QStringLiteral("Rotate Screens Upright"),
+                       this)
+            ->key());
     ui.action_Screen_Layout_Upright_Screens->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     connect(ui.action_Fullscreen, &QAction::triggered, this, &GMainWindow::ToggleFullscreen);
     connect(ui.action_Screen_Layout_Default, &QAction::triggered, this,
@@ -1169,7 +1172,7 @@ void GMainWindow::OnGameListNavigateToGamedbEntry(u64 program_id,
     if (it != compatibility_list.end())
         directory = it->second.second;
 
-    QDesktopServices::openUrl(QUrl("https://citra-emu.org/game/" + directory));
+    QDesktopServices::openUrl(QUrl(QStringLiteral("https://citra-emu.org/game/") + directory));
 }
 
 void GMainWindow::OnGameListOpenDirectory(const QString& directory) {
@@ -1232,7 +1235,7 @@ void GMainWindow::OnMenuLoadFile() {
 void GMainWindow::OnMenuInstallCIA() {
     QStringList filepaths = QFileDialog::getOpenFileNames(
         this, tr("Load Files"), UISettings::values.roms_path,
-        tr("3DS Installation File (*.CIA*)") + ";;" + tr("All Files (*.*)"));
+        tr("3DS Installation File (*.CIA*)") + QStringLiteral(";;") + tr("All Files (*.*)"));
     if (filepaths.isEmpty())
         return;
 

--- a/src/citra_qt/util/util.cpp
+++ b/src/citra_qt/util/util.cpp
@@ -8,7 +8,7 @@
 #include "citra_qt/util/util.h"
 
 QFont GetMonospaceFont() {
-    QFont font("monospace");
+    QFont font(QStringLiteral("monospace"));
     // Automatic fallback to a monospace font on on platforms without a font called "monospace"
     font.setStyleHint(QFont::Monospace);
     font.setFixedPitch(true);
@@ -18,12 +18,12 @@ QFont GetMonospaceFont() {
 QString ReadableByteSize(qulonglong size) {
     static const std::array<const char*, 6> units = {"B", "KiB", "MiB", "GiB", "TiB", "PiB"};
     if (size == 0)
-        return "0";
+        return QStringLiteral("0");
     int digit_groups = std::min<int>(static_cast<int>(std::log10(size) / std::log10(1024)),
                                      static_cast<int>(units.size()));
-    return QString("%L1 %2")
+    return QStringLiteral("%L1 %2")
         .arg(size / std::pow(1024, digit_groups), 0, 'f', 1)
-        .arg(units[digit_groups]);
+        .arg(QString::fromUtf8(units[digit_groups]));
 }
 
 QPixmap CreateCirclePixmapFromColor(const QColor& color) {


### PR DESCRIPTION
* yuzu/CMakeLists: Disable implicit QString conversions

Now that all of our code is compilable with implicit QString
conversions, we can enforce it at compile-time by disabling them.

Co-Authored-By: Mat M. <lioncash@users.noreply.github.com>

* citra_qt: Remove lots of implicit QString conversions

Co-authored-by: Mat M. <mathew1800@gmail.com>